### PR TITLE
Fix missing plugin exception in iOS

### DIFF
--- a/ios/Classes/GeofencingPlugin.m
+++ b/ios/Classes/GeofencingPlugin.m
@@ -30,10 +30,8 @@ static BOOL backgroundIsolateRun = NO;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   @synchronized(self) {
-    if (instance == nil) {
       instance = [[GeofencingPlugin alloc] init:registrar];
       [registrar addApplicationDelegate:instance];
-    }
   }
 }
 


### PR DESCRIPTION
We get Missingplugin exception for GeofencingPlugin when we log out of the app and log in again. 
We register GeofencingPlugin upon logging into the app. 
In our app, the login module is part of the native swift code and upon login, we start the flutter engine. 
Removing the check for GeofencingPlugin instance helps avoid that. @bkonyi : could you please review this? Not sure if this is the best solution but this seemed to help in our situation.