### PR TITLE
Safety checks added, if lateinit variables initialized before accessing them (Android).

### DIFF
--- a/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingService.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingService.kt
@@ -28,6 +28,7 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
     private val queue = ArrayDeque<List<Any>>()
     private lateinit var mBackgroundChannel: MethodChannel
     private lateinit var mContext: Context
+    private lateinit var sPluginRegistrantCallback: PluginRegistrantCallback
 
     companion object {
         @JvmStatic
@@ -40,19 +41,13 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
         private val sServiceStarted = AtomicBoolean(false)
 
         @JvmStatic
-        private lateinit var sPluginRegistrantCallback: PluginRegistrantCallback
-
-        @JvmStatic
         fun enqueueWork(context: Context, work: Intent) {
             enqueueWork(context, GeofencingService::class.java, JOB_ID, work)
         }
-
-        @JvmStatic
-        fun setPluginRegistrant(callback: PluginRegistrantCallback) {
-            sPluginRegistrantCallback = callback
-        }
     }
-
+    private fun setPluginRegistrant(callback: PluginRegistrantCallback) {
+        sPluginRegistrantCallback = callback
+    }
     private fun startGeofencingService(context: Context) {
         synchronized(sServiceStarted) {
             mContext = context
@@ -71,7 +66,9 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
                 sBackgroundFlutterView = FlutterNativeView(context, true)
 
                 val registry = sBackgroundFlutterView!!.pluginRegistry
-                sPluginRegistrantCallback.registerWith(registry)
+                if (::sPluginRegistrantCallback.isInitialized) {
+                    sPluginRegistrantCallback.registerWith(registry)
+                }
                 val args = FlutterRunArguments()
                 args.bundlePath = FlutterMain.findAppBundlePath(context)
                 args.entrypoint = callbackInfo.callbackName
@@ -83,7 +80,9 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
         }
         mBackgroundChannel = MethodChannel(sBackgroundFlutterView,
                 "plugins.flutter.io/geofencing_plugin_background")
-        mBackgroundChannel.setMethodCallHandler(this)
+        if (::mBackgroundChannel.isInitialized) {
+            mBackgroundChannel.setMethodCallHandler(this)
+        }
     }
 
    override fun onMethodCall(call: MethodCall, result: Result) {
@@ -91,18 +90,24 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
             "GeofencingService.initialized" -> {
                 synchronized(sServiceStarted) {
                     while (!queue.isEmpty()) {
-                        mBackgroundChannel.invokeMethod("", queue.remove())
+                        if (::mBackgroundChannel.isInitialized) {
+                            mBackgroundChannel.invokeMethod("", queue.remove())
+                        }
                     }
                     sServiceStarted.set(true)
                 }
             }
             "GeofencingService.promoteToForeground" -> {
-                mContext.startForegroundService(Intent(mContext, IsolateHolderService::class.java))
+                if (::mContext.isInitialized) {
+                    mContext.startForegroundService(Intent(mContext, IsolateHolderService::class.java))
+                }
             }
             "GeofencingService.demoteToBackground" -> {
                 val intent = Intent(mContext, IsolateHolderService::class.java)
                 intent.setAction(IsolateHolderService.ACTION_SHUTDOWN)
-                mContext.startForegroundService(intent)
+                if (::mContext.isInitialized) {
+                    mContext.startForegroundService(intent)
+                }
             }
             else -> result.notImplemented()
         }
@@ -145,7 +150,11 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
                 queue.add(geofenceUpdateList)
             } else {
                 // Callback method name is intentionally left blank.
-                Handler(mContext.mainLooper).post { mBackgroundChannel.invokeMethod("", geofenceUpdateList) }
+                Handler(mContext.mainLooper).post {
+                    if (::mBackgroundChannel.isInitialized) {
+                        mBackgroundChannel.invokeMethod("", geofenceUpdateList)
+                    }
+                }
             }
         }
     }

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,112 @@
+From 78fff7b36b2882369ff3566357f72e6856b0b423 Mon Sep 17 00:00:00 2001
+From: Usama <usama@cowlar.com>
+Date: Fri, 15 May 2020 13:05:00 +0500
+Subject: [PATCH] Safety checks added, if lateinit variables initialized before
+ accessing them
+
+---
+ .../plugins/geofencing/GeofencingService.kt   | 39 ++++++++++++-------
+ 1 file changed, 24 insertions(+), 15 deletions(-)
+
+diff --git a/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingService.kt b/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingService.kt
+index 150cdb8..de48bab 100644
+--- a/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingService.kt
++++ b/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingService.kt
+@@ -28,6 +28,7 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
+     private val queue = ArrayDeque<List<Any>>()
+     private lateinit var mBackgroundChannel: MethodChannel
+     private lateinit var mContext: Context
++    private lateinit var sPluginRegistrantCallback: PluginRegistrantCallback
+ 
+     companion object {
+         @JvmStatic
+@@ -39,20 +40,14 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
+         @JvmStatic
+         private val sServiceStarted = AtomicBoolean(false)
+ 
+-        @JvmStatic
+-        private lateinit var sPluginRegistrantCallback: PluginRegistrantCallback
+-
+         @JvmStatic
+         fun enqueueWork(context: Context, work: Intent) {
+             enqueueWork(context, GeofencingService::class.java, JOB_ID, work)
+         }
+-
+-        @JvmStatic
+-        fun setPluginRegistrant(callback: PluginRegistrantCallback) {
+-            sPluginRegistrantCallback = callback
+-        }
+     }
+-
++    private fun setPluginRegistrant(callback: PluginRegistrantCallback) {
++        sPluginRegistrantCallback = callback
++    }
+     private fun startGeofencingService(context: Context) {
+         synchronized(sServiceStarted) {
+             mContext = context
+@@ -71,7 +66,9 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
+                 sBackgroundFlutterView = FlutterNativeView(context, true)
+ 
+                 val registry = sBackgroundFlutterView!!.pluginRegistry
+-                sPluginRegistrantCallback.registerWith(registry)
++                if (::sPluginRegistrantCallback.isInitialized) {
++                    sPluginRegistrantCallback.registerWith(registry)
++                }
+                 val args = FlutterRunArguments()
+                 args.bundlePath = FlutterMain.findAppBundlePath(context)
+                 args.entrypoint = callbackInfo.callbackName
+@@ -83,7 +80,9 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
+         }
+         mBackgroundChannel = MethodChannel(sBackgroundFlutterView,
+                 "plugins.flutter.io/geofencing_plugin_background")
+-        mBackgroundChannel.setMethodCallHandler(this)
++        if (::mBackgroundChannel.isInitialized) {
++            mBackgroundChannel.setMethodCallHandler(this)
++        }
+     }
+ 
+    override fun onMethodCall(call: MethodCall, result: Result) {
+@@ -91,18 +90,24 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
+             "GeofencingService.initialized" -> {
+                 synchronized(sServiceStarted) {
+                     while (!queue.isEmpty()) {
+-                        mBackgroundChannel.invokeMethod("", queue.remove())
++                        if (::mBackgroundChannel.isInitialized) {
++                            mBackgroundChannel.invokeMethod("", queue.remove())
++                        }
+                     }
+                     sServiceStarted.set(true)
+                 }
+             }
+             "GeofencingService.promoteToForeground" -> {
+-                mContext.startForegroundService(Intent(mContext, IsolateHolderService::class.java))
++                if (::mContext.isInitialized) {
++                    mContext.startForegroundService(Intent(mContext, IsolateHolderService::class.java))
++                }
+             }
+             "GeofencingService.demoteToBackground" -> {
+                 val intent = Intent(mContext, IsolateHolderService::class.java)
+                 intent.setAction(IsolateHolderService.ACTION_SHUTDOWN)
+-                mContext.startForegroundService(intent)
++                if (::mContext.isInitialized) {
++                    mContext.startForegroundService(intent)
++                }
+             }
+             else -> result.notImplemented()
+         }
+@@ -145,7 +150,11 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
+                 queue.add(geofenceUpdateList)
+             } else {
+                 // Callback method name is intentionally left blank.
+-                Handler(mContext.mainLooper).post { mBackgroundChannel.invokeMethod("", geofenceUpdateList) }
++                Handler(mContext.mainLooper).post {
++                    if (::mBackgroundChannel.isInitialized) {
++                        mBackgroundChannel.invokeMethod("", geofenceUpdateList)
++                    }
++                }
+             }
+         }
+     }
+-- 
+2.20.1
+


### PR DESCRIPTION
**Flutter Channel: Stable**
**FlutterGeofencing Branch : Master [1da0841]**

Android App crashed, when registering geofence. Issue was that lateinit variable (sPluginRegistrantCallback) was accessing before initialization. So added safety checks for all lateinit variables and it resolved.

**Error:**
E/AndroidRuntime(23524): java.lang.RuntimeException: Unable to create service io.flutter.plugins.geofencing.GeofencingService: kotlin.UninitializedPropertyAccessException: lateinit property sPluginRegistrantCallback has not been initialized
E/AndroidRuntime(23524): 	at android.app.ActivityThread.handleCreateService(ActivityThread.java:3966)
E/AndroidRuntime(23524): 	at android.app.ActivityThread.access$1500(ActivityThread.java:220)
E/AndroidRuntime(23524): 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1876)
E/AndroidRuntime(23524): 	at android.os.Handler.dispatchMessage(Handler.java:107)
E/AndroidRuntime(23524): 	at android.os.Looper.loop(Looper.java:214)
E/AndroidRuntime(23524): 	at android.app.ActivityThread.main(ActivityThread.java:7397)
E/AndroidRuntime(23524): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(23524): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
E/AndroidRuntime(23524): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:935)
E/AndroidRuntime(23524): Caused by: kotlin.UninitializedPropertyAccessException: lateinit property sPluginRegistrantCallback has not been initialized
E/AndroidRuntime(23524): 	at io.flutter.plugins.geofencing.GeofencingService.startGeofencingService(GeofencingService.kt:70)
E/AndroidRuntime(23524): 	at io.flutter.plugins.geofencing.GeofencingService.onCreate(GeofencingService.kt:116)
E/AndroidRuntime(23524): 	at android.app.ActivityThread.handleCreateService(ActivityThread.java:3954)
E/AndroidRuntime(23524): 	... 8 more
I/Process (23524): Sending signal. PID: 23524 SIG: 9
